### PR TITLE
Fix tracing

### DIFF
--- a/src/bomi/player/mpv_property.hpp
+++ b/src/bomi/player/mpv_property.hpp
@@ -84,8 +84,6 @@ using MpvFile = MpvLocal8Bit;
 using MpvFile = MpvUtf8;
 #endif
 
-SIA _ToLog(const MpvFile &file) -> QByteArray { return _ToLog(file.data); }
-
 struct MpvFileList {
     MpvFileList() = default;
     MpvFileList(const QStringList &names): names(names) { }


### PR DESCRIPTION
1. check "Preferences > General > Application > Load last played media on execution"
1. open a local video file
1. pause
1. set "Preferences > General > Application > Logging > stdout" to "trace"
1. restart bomi
1. click play

Expected: the video starts playing
Actual: bomi crashes with stack overflow
