### PR TITLE
run src/mpv/version.sh to define VERSION and BUILDDATE

### DIFF
--- a/build-mpv.in
+++ b/build-mpv.in
@@ -28,7 +28,10 @@ fi
 
 orig="$(pwd)"
 
-cd src/mpv && $py ./waf clean; $py ./waf distclean; $py ./waf configure $args && \
+# run src/mpv/version.sh to define VRESION and BUILDDATE
+cd src/mpv && ./version.sh
+
+$py ./waf clean; $py ./waf distclean; $py ./waf configure $args && \
 $py ./waf build -j $njobs && $py ./waf install
 
 cd "$orig"


### PR DESCRIPTION
When building I got an error in the mpv build process stating that VERSION and BUILDDATE were not defined in src/mpv/version.c
I figured this was because the src/mpv/version.sh script is never run so i added the execution of said script in build-mpv.in
additionally I deleted the 'cd src/mpv' in the line after since I already do the cd in my script execution.